### PR TITLE
added max_i variable to fix the ArraryIndexOutOfBoundsException issue

### DIFF
--- a/src/gov/nih/mipav/view/renderer/WildMagic/WormUntwisting/LatticeModel.java
+++ b/src/gov/nih/mipav/view/renderer/WildMagic/WormUntwisting/LatticeModel.java
@@ -3093,8 +3093,11 @@ public class LatticeModel {
 		for(int j = 0; j < numEllipsePts; ++j) {
 			edgePoints[j] = displayContours[latticeSlices.length + j].getCurves().elementAt(0);
 		}
+		
+		//chend 2024/02/01: added max_i for fix ArrayIndexOutOfBoundException
+		int max_i = Math.min(dimZ, rightPositions.size());
 				
-		for (int i = 0; i < dimZ; i++)
+		for (int i = 0; i < max_i; i++)
 		{			
 			VOIContour contour = new VOIContour(true);
 


### PR DESCRIPTION
There was an error noticed from Johnny on 2024/01/24 with the straightening function was not generate output properly. Thus, based on the error message, an attempt was made to fix the `ArrayIndexOutOfBoundsException` by added max_variable to match the `dimZ` with `rightPosition.size()`.